### PR TITLE
Fix a out-of-date comment

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
@@ -117,7 +117,7 @@ public class MasterServer implements IStoppable {
         zkMasterClient.setStoppable(this);
 
         // regular heartbeat
-        // delay 5 seconds, send heartbeat every 30 seconds
+        // delay 5 seconds, send heartbeat every 10 seconds
         heartbeatMasterService.
                 scheduleAtFixedRate(heartBeatThread, 5, masterConfig.getMasterHeartbeatInterval(), TimeUnit.SECONDS);
 


### PR DESCRIPTION
From the default of the parameter master.heartbeat.interval, it can be seen that the default heart beat interval is 10s.

## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds checkstyle plugin.)*

## Brief change log

*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
